### PR TITLE
This improved regex parses all of our network and system logs properly

### DIFF
--- a/input/parser.go
+++ b/input/parser.go
@@ -31,7 +31,7 @@ type ParsedMessage struct {
 // Returns an initialized Rfc5424Parser.
 func NewRfc5424Parser() *Rfc5424Parser {
 	p := &Rfc5424Parser{}
-	r := regexp.MustCompile(`(?s)<([0-9]{1,3})>([0-9])\s(.+)\s(.+)\s(.+)\s([0-9]{1,5})\s([\w-]+)\s(.+$)`)
+	r := regexp.MustCompile(`(?s)<([0-9]{1,3})>([0-9])\s(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}[+-]\d{2}\:\d{2})\s+([\S]+)\s([0-9\S]+)\s+([\S]*)\s+-\s+([\S]*):?\s+(.+$)`)
 	p.regex = r
 
 	// Initialize metrics


### PR DESCRIPTION
Some lines that were dropped:

<27>1 2015-03-02T22:53:45-08:00 localhost.localdomain puppet-agent 5334 -     mirrorurls.extend(list(self.metalink_data.urls()))
<29>1 2015-03-03T06:49:08-08:00 localhost.localdomain puppet-agent 51564 - (/Stage[main]/Users_prd/Ssh_authorized_key[1063-username]) Dependency Group[group] has failures: true
<30>1 2015-03-03T06:49:08-08:00 localhost.localdomain /usr/sbin/gmond 38163 - Error 1 sending the modular data for proc_run#012
<30>1 2015-03-03T06:47:18-08:00 localhost.localdomain /usr/sbin/gmond 31411 - Error 1 sending the modular data for heartbeat#012
<86>1 2015-03-02T22:23:07-08:00 localhost.localdomain sshd 17992 - Accepted publickey for username from 127.0.0.1 port 44656 ssh2
<142>1 2015-03-02T22:23:07-08:00 localhost.localdomain Keepalived_vrrp 21125 - VRRP_Instance(VI_1) ignoring received advertisment...
<142>1 2015-03-02T22:23:07-08:00 localhost.localdomain Keepalived_vrrp 17875 - bogus VRRP packet received on bond0 !!!
<158>1 2015-03-02T22:23:07-08:00 localhost.localdomain fpc0  - PFE_FW_SYSLOG_IP: FW: ae3.0        D  tcp 192.168.1.2 192.168.1.1 47320    25 (1 packets)
